### PR TITLE
Remove website app request check

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_request.yaml
+++ b/.github/ISSUE_TEMPLATE/app_request.yaml
@@ -33,5 +33,3 @@ body:
           required: true
         - label: I've checked all open and closed pull requests and my request is not there.
           required: true
-        - label: I've checked the [website](https://truecharts.org/apps/app-requests/) and my request is not there.
-          required: true


### PR DESCRIPTION
The "App Requests" page was removed from the site in this commit - https://github.com/truecharts/pub/commit/6857fe241ff5237babe44ca9173bd29999d3da24 - so doesn't make sense to ask people to check it out any more.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
